### PR TITLE
ロガーの実装

### DIFF
--- a/Onset/src/config.php
+++ b/Onset/src/config.php
@@ -54,3 +54,8 @@ $config["maxNick"] = 20;
  *デフォルトでは10日で設定しています(60秒×60分×24時間×10日)
  */
 $config["roomDelTime"] = 60 * 60 * 24 * 10;
+
+/*
+ * ログファイル
+ */
+$config['saveLog'] = __DIR__ . '/../log.txt';

--- a/Onset/src/core.php
+++ b/Onset/src/core.php
@@ -1,7 +1,6 @@
 <?php
 require_once(dirname(__FILE__).'/config.php');
 
-
 class Onset
 {
     public static function isValidAccess($randKey)
@@ -51,5 +50,59 @@ class Onset
             $ret = "";
         }
         return str_replace('onset: ', '', $ret);
+    }
+}
+
+/**
+ * Onset logger
+ */
+class Logger
+{
+    /**
+     * @var DEBUG  デバッグ
+     * @var INFO   情報
+     * @var WARN   警告
+     * @var DANGER 異常
+     */
+    const DEBUG  = 'Debug       ';
+    const INFO   = 'Information ';
+    const WARN   = 'Warning     ';
+    const DANGER = 'Danger      ';
+
+    /**
+     * Logging function
+     * ログを$config['saveLog']のファイルに記録します。
+     *
+     * $level にはself::DEBUG, self::INFO, self::WARN, self::DANGER などが入ります。
+     *
+     * e.g. Logger::log('Super error!', Logger::DANGER);
+     *
+     * @param string $log   text
+     * @param string $level Logging level
+     *
+     * @return void
+     */
+    public static function log($log, $level = self::INFO)
+    {
+        global $config;
+
+        $file = $config['saveLog'];
+
+        $format = date('m/d H:i:s ')."%s: %s\n";
+
+        switch ($level) {
+        case self::DEBUG:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::INFO:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::WARN:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::DANGER:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        }
     }
 }


### PR DESCRIPTION
開発・デプロイなどに発生するエラーの追跡に有効だと思われるロガーを実装しました。
実装箇所は`src/core.php`で、そのまま`require_once 'src/core.php'`で実行可能です。

現在、実際のコードにはログの記録コードは入れていません。

使い方:

``` php
require_once 'src/core.php';

// デバッグ情報
Logger::log('Debug. function getter() is working.', Logger::DEBUG);
// 一般情報
Logger::log('Information. All function are now avaialble.', Logger::INFO); 
// 警告
Logger::log('Warning. Enemy opposites are coming.', Logger::WARN);
// 異常
Logger::log('Danger. Cannot divide by 0.', Logger::DANGER);
```
