### PR TITLE
変数表現の改善 / クラス名の変更 / ロガーの改善

### DIFF
--- a/Onset/public_html/Onset.php
+++ b/Onset/public_html/Onset.php
@@ -7,8 +7,8 @@ if(!isset($_SESSION['onset_roomid'])){
 }
 
 require_once('src/config.php');
-$url = config::bcdiceURL;
-$s = config::enableSSL ? 's' : '';
+$url = Config::bcdiceURL;
+$s = Config::enableSSL ? 's' : '';
 $sysList = explode("\n", file_get_contents("http{$s}://{$url}?list=1"));
 ?>
 

--- a/Onset/public_html/Onset.php
+++ b/Onset/public_html/Onset.php
@@ -7,8 +7,8 @@ if(!isset($_SESSION['onset_roomid'])){
 }
 
 require_once('src/config.php');
-$url = $config['bcdiceURL'];
-$s = $config['enableSSL'] ? 's' : '';
+$url = config::bcdiceURL;
+$s = config::enableSSL ? 's' : '';
 $sysList = explode("\n", file_get_contents("http{$s}://{$url}?list=1"));
 ?>
 

--- a/Onset/public_html/Onset.php
+++ b/Onset/public_html/Onset.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 
-if(!isset($_SESSION['onset_room'])){
+if(!isset($_SESSION['onset_roomid'])){
     header("Location: index.php");
     die();
 }
@@ -32,7 +32,7 @@ $sysList = explode("\n", file_get_contents("http{$s}://{$url}?list=1"));
     </header>
     <div class="contents">
     <div class="form">
-        <input type="text" id="nick" value=<?= $_SESSION['onset_nick'] ?>>(<?= $_SESSION['onset_id'] ?>)
+        <input type="text" id="nick" value=<?= $_SESSION['onset_playername'] ?>>(<?= $_SESSION['onset_playerid'] ?>)
         <select id="sys">
         <option value="None" selected>指定なし</option>
 <?php foreach($sysList as $value): ?>

--- a/Onset/public_html/bcdice/bcdiceCore.rb
+++ b/Onset/public_html/bcdice/bcdiceCore.rb
@@ -1,4 +1,4 @@
-#!/bin/ruby -Ku 
+#!/usr/local/bin/ruby -Ku 
 # -*- coding: utf-8 -*-
 
 require 'log'

--- a/Onset/public_html/bcdice/bcdiceCore.rb
+++ b/Onset/public_html/bcdice/bcdiceCore.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby -Ku 
+#!/bin/ruby -Ku
 # -*- coding: utf-8 -*-
 
 require 'log'

--- a/Onset/public_html/bcdice/roll.rb
+++ b/Onset/public_html/bcdice/roll.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby -Ku
+#!/usr/bin/ruby -Ku
 #--*-coding:utf-8-*--
 
 $LOAD_PATH << File.dirname(__FILE__)

--- a/Onset/public_html/bcdice/roll.rb
+++ b/Onset/public_html/bcdice/roll.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby -Ku
+#!/usr/local/bin/ruby -Ku
 #--*-coding:utf-8-*--
 
 $LOAD_PATH << File.dirname(__FILE__)
@@ -8,7 +8,7 @@ require 'bcdiceCore.rb'
 require 'configBcDice.rb'
 
 class OnsetBCDiceMaker < BCDiceMaker
-  
+
   def newBcDice
     bcdice = OnsetBCDice.new(self, @cardTrader, @diceBot, @counterInfos, @tableFileData)
     return bcdice
@@ -16,7 +16,7 @@ class OnsetBCDiceMaker < BCDiceMaker
 end
 
 class OnsetBCDice < BCDice
-  
+
   def setNick(nick)
     @nick_e = nick
   end

--- a/Onset/public_html/index.php
+++ b/Onset/public_html/index.php
@@ -1,10 +1,10 @@
 <?php
 require_once('src/core.php');
 
-$dir = config::roomSavepath;
+$dir = Config::roomSavepath;
 $roomList = [];
 foreach(Onset::getRoomlist() as $room => $data){
-    if(time() - filemtime($dir.$data['path']) > config::roomDelTime) continue;
+    if(time() - filemtime($dir.$data['path']) > Config::roomDelTime) continue;
     $roomList[$room] = $data;
 }
 

--- a/Onset/public_html/index.php
+++ b/Onset/public_html/index.php
@@ -3,10 +3,10 @@ require_once('src/config.php');
 require_once('src/core.php');
 
 $dir = $config['roomSavepath'];
-$roomlist = [];
+$roomList = [];
 foreach(Onset::getRoomlist() as $room => $data){
     if(time() - filemtime($dir.$data['path']) > $config['roomDelTime']) continue;
-    $roomlist[$room] = $data;
+    $roomList[$room] = $data;
 }
 
 session_start();
@@ -33,9 +33,9 @@ $welcomeMessage = file_get_contents('welcomeMessage.html');
         <h1>Onset!</h1>
         <article><?=$welcomeMessage?></article>
     </div>
-    
+
     <hr />
-    
+
     <div class="join">
         <a id="toggle" onclick="toggle()">部屋の作成/削除</a>
         <form class="form" id="enter">
@@ -48,7 +48,7 @@ $welcomeMessage = file_get_contents('welcomeMessage.html');
 
             <div class="list">
                 <p>部屋一覧</p>
-                <?php foreach($roomlist as $key => $value) : ?>
+                <?php foreach($roomList as $key => $value) : ?>
                     <label class="room">
                         <input type="radio" name="room" value="<?=$key?>"><?=$key?>
                     </label>
@@ -58,7 +58,7 @@ $welcomeMessage = file_get_contents('welcomeMessage.html');
     </div>
 
     <div class="edit">
-        
+
         <a onclick="toggle()" id="toggle">閉じる</a>
 
         <h2>作成</h2>
@@ -80,7 +80,7 @@ $welcomeMessage = file_get_contents('welcomeMessage.html');
             <span id="removeNotice" class="notice"></span>
         <div class="list">
                 <p>部屋一覧</p>
-                <?php foreach($roomlist as $key => $value) : ?>
+                <?php foreach($roomList as $key => $value) : ?>
                     <label class="room">
                         <input type="radio" name="room" value="<?=$key?>"><?=$key?>
                     </label>

--- a/Onset/public_html/index.php
+++ b/Onset/public_html/index.php
@@ -1,11 +1,10 @@
 <?php
-require_once('src/config.php');
 require_once('src/core.php');
 
-$dir = $config['roomSavepath'];
+$dir = config::roomSavepath;
 $roomList = [];
 foreach(Onset::getRoomlist() as $room => $data){
-    if(time() - filemtime($dir.$data['path']) > $config['roomDelTime']) continue;
+    if(time() - filemtime($dir.$data['path']) > config::roomDelTime) continue;
     $roomList[$room] = $data;
 }
 

--- a/Onset/public_html/js/chat_rw.js
+++ b/Onset/public_html/js/chat_rw.js
@@ -1,7 +1,6 @@
 var finaltime = 1;
 
 function get_log(){
-    
     $.ajax({
         url: "src/read.php",
         type: "POST",
@@ -25,24 +24,24 @@ function get_log(){
 
 
 function send_chat(){
-    
-    var nick = $("#nick").val().trim();
-    var text = $("#text").val().trim();
-    var sys = $("#sys").val().trim();
+    var playerName  = $("#nick").val().trim();
+    var chatContent = $("#text").val().trim();
+    var diceSystem  = $("#sys").val().trim();
 
-    if(nick === "" || text === ""){
+    if(playerName === "" || chatContent === ""){
         $(".notice").html("<b>名前と本文を入力してください</b>");
         return 0;
     }
+
     $("#onsetNotice").text('送信中...');
-    
+
     $.ajax({
         url: "src/write.php",
         type: "POST",
         data: {
-            "nick": nick,
-            "text": text,
-            "sys": sys
+            "playerName" : playerName,
+            "chatContent": chatContent,
+            "diceSystem" : diceSystem
         },
         dataType:"json",
         beforeSend: function(xhr) {

--- a/Onset/public_html/js/script.js
+++ b/Onset/public_html/js/script.js
@@ -8,24 +8,25 @@ function toggle(){
 }
 
 function enterRoom(){
-    var enter = $("#enter");
-    var nick = enter.find("#nick").val();
-    var pass = enter.find("#pass").val();
-    var room = enter.find("input[name='room']:checked").val();
-    
-    if(nick === '' || pass === '' || room === undefined){
+    var enter      = $("#enter");
+    var playerName = enter.find("#nick").val();
+    var roomName   = enter.find("input[name='room']:checked").val();
+    var roomPw     = enter.find("#pass").val();
+
+    if(playerName === '' || roomName === undefined || roomPw === ''){
         $('#enterNotice').text('空欄があります');
         return;
     }
+
     $('#enterNotice').text('処理中...');
-    
+
     $.ajax({
         url:"src/login.php",
         type:"POST",
         data:{
-            "nick":nick,
-            "pass":pass,
-            "room":room
+            "playerName": playerName,
+            "roomName"  : roomName,
+            "roomPw"    : roomPw
         },
         dataType:"json",
         beforeSend: function(xhr) {
@@ -43,23 +44,23 @@ function enterRoom(){
 }
 
 function createRoom(){
-    var create = $("#create");
-    var pass = create.find("#pass").val();
-    var room = create.find("#room").val();
-    
-    if(rand === '' || pass === '' || room === ''){
+    var create   = $("#create");
+    var roomName = create.find("#room").val();
+    var roomPw   = create.find("#pass").val();
+
+    if(rand === '' || roomName === '' || roomPw === ''){
         $('#createNotice').text('空欄があります');
         return;
     }
     $('#createNotice').text('処理中...');
-    
+
     $.ajax({
         url:"src/createRoom.php",
         type:"POST",
         data:{
-            "rand":rand,
-            "pass":pass,
-            "room":room
+            "roomName" : roomName,
+            "roomPw"   : roomPw,
+            "rand"     : rand
         },
         dataType:"json",
         beforeSend: function(xhr) {
@@ -77,23 +78,23 @@ function createRoom(){
 }
 
 function removeRoom(){
-    var enter = $("#remove");
-    var pass = enter.find("#pass").val();
-    var room = enter.find("input[name='room']:checked").val();
-    
-    if(rand === '' || pass === '' || room === undefined){
+    var enter    = $("#remove");
+    var roomPw   = enter.find("#pass").val();
+    var roomName = enter.find("input[name='room']:checked").val();
+
+    if(rand === '' || roomName === undefined || roomPw === ''){
         $('#removeNotice').text('空欄があります');
         return;
     }
     $('#removeNotice').text('処理中...');
-    
+
     $.ajax({
         url:"src/removeRoom.php",
         type:"POST",
         data:{
-            "rand":rand,
-            "pass":pass,
-            "room":room
+            "roomName":roomName,
+            "roomPw":roomPw,
+            "rand":rand
         },
         dataType:"json",
         beforeSend: function(xhr) {

--- a/Onset/public_html/src/checkLoginUser.php
+++ b/Onset/public_html/src/checkLoginUser.php
@@ -11,8 +11,8 @@ if(!$roomId || !$playerId){
     die();
 }
 
-$roomDir = $config['roomSavepath'].$roomId."/connect/";
-$arr = scandir($roomDir);
+$roomDir = config::roomSavepath.$room."/connect/";
+$loginUserList = scandir($roomDir);
 
 if($_POST['lock'] === 'unlock') {
     file_put_contents($roomDir.$playerId, time()."\n".$_SESSION['onset_playername']);
@@ -21,17 +21,17 @@ if($_POST['lock'] === 'unlock') {
 
 file_put_contents($roomDir.$roomId, time()."\n".$_SESSION['onset_playername']."\nlocked");
 
-foreach($arr as $value) {
-    if($value == "." || $value == "..") continue;
+foreach($loginUserList as $playerId) {
+    if($playerId == "." || $playerId == "..") continue;
 
-    list($time, $nick, $isLock) = explode("\n", file_get_contents($roomDir.$value));
+    list($time, $playerName, $isLock) = explode("\n", file_get_contents($roomDir.$value));
 
     if($time + 5 < time() && $isLock !== 'locked') {
         unlink($roomDir.$value);
         continue;
     }
 
-    $ret .= $nick.'#'.$value."\n";
+    $ret .= $playerName.'#'.$playerId."\n";
 
     $num++;
 }

--- a/Onset/public_html/src/checkLoginUser.php
+++ b/Onset/public_html/src/checkLoginUser.php
@@ -1,33 +1,33 @@
 <?php
-require_once('config.php');
+require_once 'core.php';
 
 session_start();
 
-$room = isset($_SESSION['onset_room']) 	&& $_SESSION['onset_room']	!= NULL ? $_SESSION['onset_room'] : FALSE;
-$id = isset($_SESSION['onset_id']) && $_SESSION['onset_id'] != NULL ? $_SESSION['onset_id'] : FALSE;
+$roomId   = isset($_SESSION['onset_roomid'])   && $_SESSION['onset_roomid']   != NULL ? $_SESSION['onset_roomid']   : FALSE;
+$playerId = isset($_SESSION['onset_playerid']) && $_SESSION['onset_playerid'] != NULL ? $_SESSION['onset_playerid'] : FALSE;
 
-if(!$room || !$id){
+if(!$roomId || !$playerId){
     echo "不正なアクセス";
     die();
 }
 
-$dir = $config['roomSavepath'].$room."/connect/";
-$arr = scandir($dir);
+$roomDir = $config['roomSavepath'].$roomId."/connect/";
+$arr = scandir($roomDir);
 
 if($_POST['lock'] === 'unlock') {
-    file_put_contents($dir.$id, time()."\n".$_SESSION['onset_nick']);
+    file_put_contents($roomDir.$playerId, time()."\n".$_SESSION['onset_playername']);
     die();
 }
 
-file_put_contents($dir.$id, time()."\n".$_SESSION['onset_nick']."\nlocked");
+file_put_contents($roomDir.$roomId, time()."\n".$_SESSION['onset_playername']."\nlocked");
 
 foreach($arr as $value) {
     if($value == "." || $value == "..") continue;
 
-    list($time, $nick, $isLock) = explode("\n", file_get_contents($dir.$value));
+    list($time, $nick, $isLock) = explode("\n", file_get_contents($roomDir.$value));
 
     if($time + 5 < time() && $isLock !== 'locked') {
-        unlink($dir.$value);
+        unlink($roomDir.$value);
         continue;
     }
 

--- a/Onset/public_html/src/checkLoginUser.php
+++ b/Onset/public_html/src/checkLoginUser.php
@@ -11,7 +11,7 @@ if(!$roomId || !$playerId){
     die();
 }
 
-$roomDir = config::roomSavepath.$room."/connect/";
+$roomDir = config::roomSavepath.$roomId."/connect/";
 $loginUserList = scandir($roomDir);
 
 if($_POST['lock'] === 'unlock') {
@@ -24,10 +24,10 @@ file_put_contents($roomDir.$roomId, time()."\n".$_SESSION['onset_playername']."\
 foreach($loginUserList as $playerId) {
     if($playerId == "." || $playerId == "..") continue;
 
-    list($time, $playerName, $isLock) = explode("\n", file_get_contents($roomDir.$value));
+    list($time, $playerName, $isLock) = explode("\n", file_get_contents($roomDir.$playerId));
 
     if($time + 5 < time() && $isLock !== 'locked') {
-        unlink($roomDir.$value);
+        unlink($roomDir.$playerId);
         continue;
     }
 

--- a/Onset/public_html/src/checkLoginUser.php
+++ b/Onset/public_html/src/checkLoginUser.php
@@ -11,7 +11,7 @@ if(!$roomId || !$playerId){
     die();
 }
 
-$roomDir = config::roomSavepath.$roomId."/connect/";
+$roomDir = Config::roomSavepath.$roomId."/connect/";
 $loginUserList = scandir($roomDir);
 
 if($_POST['lock'] === 'unlock') {

--- a/Onset/public_html/src/checkStatus.php
+++ b/Onset/public_html/src/checkStatus.php
@@ -1,6 +1,5 @@
 <?php
-require_once('core.php');
-require_once('config.php');
+require_once 'core.php';
 header('Content-Type: text/plain');
 
 $coreStatusArr = array();
@@ -13,12 +12,13 @@ foreach ($coreStatusArr as $key => $val) {
     echo $val ? "" : $key."にアクセスできません\n";
 }
 
-$url = $config['bcdiceURL'];
-$s = $config['enableSSL'] ? 's' : '';
-file_get_contents("http{$s}://{$url}?list=1");
+$BCDiceURL = config::bcdiceURL;
+$SSL       = config::enableSSL ? 's' : '';
+
+file_get_contents("http{$SSL}://{$BCDiceURL}?list=1");
 echo strpos($http_response_header[0], '200') !== FALSE ? "ダイスボットの設定は正常です\n" : "ダイスボットにアクセスできません\n";
 
-$roomPath = $config['roomSavepath'];
-$roomDirStatus = is_writable($roomPath) && is_readable($roomPath);
-$roomlistStatus = is_writable($roomPath) && is_readable($roomPath);
-echo $roomDirStatus && $roomlistStatus ? "部屋データの設定は正常です\n" : "部屋データにアクセスできません\n";
+$dir = config::roomSavepath;
+$dirStatus = is_writable($dir) && is_readable($dir);
+$roomListStatus = is_writable($dir) && is_readable($dir);
+echo $dirStatus && $roomListStatus ? "部屋データの設定は正常です\n" : "部屋データにアクセスできません\n";

--- a/Onset/public_html/src/checkStatus.php
+++ b/Onset/public_html/src/checkStatus.php
@@ -12,13 +12,13 @@ foreach ($coreStatusArr as $key => $val) {
     echo $val ? "" : $key."にアクセスできません\n";
 }
 
-$BCDiceURL = config::bcdiceURL;
-$SSL       = config::enableSSL ? 's' : '';
+$BCDiceURL = Config::bcdiceURL;
+$SSL       = Config::enableSSL ? 's' : '';
 
 file_get_contents("http{$SSL}://{$BCDiceURL}?list=1");
 echo strpos($http_response_header[0], '200') !== FALSE ? "ダイスボットの設定は正常です\n" : "ダイスボットにアクセスできません\n";
 
-$dir = config::roomSavepath;
+$dir = Config::roomSavepath;
 $dirStatus = is_writable($dir) && is_readable($dir);
 $roomListStatus = is_writable($dir) && is_readable($dir);
 echo $dirStatus && $roomListStatus ? "部屋データの設定は正常です\n" : "部屋データにアクセスできません\n";

--- a/Onset/public_html/src/checkStatus.php
+++ b/Onset/public_html/src/checkStatus.php
@@ -1,9 +1,5 @@
 <?php
-<<<<<<< HEAD
 require_once 'core.php';
-=======
-require_once('core.php');
->>>>>>> 737c102658c3bcaad9d92a4e018bf67910c14d6c
 header('Content-Type: text/plain');
 
 $coreStatusArr = array();
@@ -16,7 +12,6 @@ foreach ($coreStatusArr as $key => $val) {
     echo $val ? "" : $key."にアクセスできません\n";
 }
 
-<<<<<<< HEAD
 $BCDiceURL = Config::bcdiceURL;
 $SSL       = Config::enableSSL ? 's' : '';
 
@@ -27,14 +22,3 @@ $dir = Config::roomSavepath;
 $dirStatus = is_writable($dir) && is_readable($dir);
 $roomListStatus = is_writable($dir) && is_readable($dir);
 echo $dirStatus && $roomListStatus ? "部屋データの設定は正常です\n" : "部屋データにアクセスできません\n";
-=======
-$url = config::bcdiceURL;
-$s = config::enableSSL ? 's' : '';
-file_get_contents("http{$s}://{$url}?list=1");
-echo strpos($http_response_header[0], '200') !== FALSE ? "ダイスボットの設定は正常です\n" : "ダイスボットにアクセスできません\n";
-
-$roomPath = config::roomSavepath;
-$roomDirStatus = is_writable($roomPath) && is_readable($roomPath);
-$roomlistStatus = is_writable($roomPath) && is_readable($roomPath);
-echo $roomDirStatus && $roomlistStatus ? "部屋データの設定は正常です\n" : "部屋データにアクセスできません\n";
->>>>>>> 737c102658c3bcaad9d92a4e018bf67910c14d6c

--- a/Onset/public_html/src/config.php
+++ b/Onset/public_html/src/config.php
@@ -4,53 +4,61 @@
  * マスターパスワードや管理設定はここから行えます
  */
 
-/*
- * Onsetの管理パスワードです
- * 簡単なものに設定しないでください
- */
-$config['pass'] = "";
 
-/*
- * 部屋データを置くディレクトリへのパスです
- * カスタマイズする場合は良しなに...
- */
-$config['roomSavepath'] = __DIR__ . "/../../room/";
+class config{
+    /*
+     * Onsetの管理パスワードです
+     * 簡単なものに設定しないでください
+     */
+    const pass = "";
 
-/*
- * bcdiceへのURL
- * ダイスボットへのパスを書いてください
- * デフォルトではindex.phpと同じ階層にあります
- */
-$config['bcdiceURL'] = "trpg.moegi.mydns.jp/TRPG/Onset/public_html/bcdice/roll.rb";
+    /*
+     * 部屋データを置くディレクトリへのパスです
+     * カスタマイズする場合は良しなに...
+     */
+    const roomSavepath = __DIR__."/../../room/";
 
-/*
- * SSLを有効にするか
- * URLの先頭についてる、httpsってやつです
- * わからない人はいじらないほうがいいと思います
- */
-$config['enableSSL'] = true;
+    /*
+     * bcdiceへのURL
+     * ダイスボットへのパスを書いてください
+     * デフォルトではindex.phpと同じ階層にあります
+     */
+    const bcdiceURL = "trpg.moegi.mydns.jp/TRPG/Onset/public_html/bcdice/roll.rb";
 
-/*
- * 最大部屋数
- * 1部屋当たりはそこまで容量食いません
- * サーバーのスペックに合わせて適当に設定してください
- */
-$config["roomLimit"] = 100;
+    /*
+     * SSLを有効にするか
+     * URLの先頭についてる、httpsってやつです
+     * わからない人はいじらないほうがいいと思います
+     */
+    const enableSSL = true;
 
-/*
- * 部屋名の長さ制限
- */
-$config['maxRoomName'] = 30;
+    /*
+     * 最大部屋数
+     * 1部屋当たりはそこまで容量食いません
+     * サーバーのスペックに合わせて適当に設定してください
+     */
+    const roomLimit = 100;
 
-/*
- * チャットの最大文字数と、ニックネームの最大文字数
- */
-$config["maxText"] = 300;
-$config["maxNick"] = 20;
+    /*
+     * 部屋名の長さ制限
+     */
+    const maxRoomName = 30;
 
-/*
- *部屋が自動削除されるまでの時間
- *秒数で指定してください
- *デフォルトでは10日で設定しています(60秒×60分×24時間×10日)
- */
-$config["roomDelTime"] = 60 * 60 * 24 * 10;
+    /*
+     * チャットの最大文字数と、ニックネームの最大文字数
+     */
+    const maxText = 300;
+    const maxNick = 20;
+
+    /*
+     *部屋が自動削除されるまでの時間
+     *秒数で指定してください
+     *デフォルトでは10日で設定しています(60秒×60分×24時間×10日)
+     */
+    const roomDelTime  = 60 * 60 * 24 * 10;
+
+    /*
+     * ログファイル
+     */
+    const saveLog = __DIR__ . '/../log.txt';
+}

--- a/Onset/public_html/src/config.php
+++ b/Onset/public_html/src/config.php
@@ -4,8 +4,8 @@
  * マスターパスワードや管理設定はここから行えます
  */
 
-
-class config{
+class Config
+{
     /*
      * Onsetの管理パスワードです
      * 簡単なものに設定しないでください
@@ -23,14 +23,14 @@ class config{
      * ダイスボットへのパスを書いてください
      * デフォルトではindex.phpと同じ階層にあります
      */
-    const bcdiceURL = "trpg.moegi.mydns.jp/TRPG/Onset/public_html/bcdice/roll.rb";
+    const bcdiceURL = "localhost/Onset/bcdice/roll.rb";
 
     /*
      * SSLを有効にするか
      * URLの先頭についてる、httpsってやつです
      * わからない人はいじらないほうがいいと思います
      */
-    const enableSSL = true;
+    const enableSSL = false;
 
     /*
      * 最大部屋数

--- a/Onset/public_html/src/config.php
+++ b/Onset/public_html/src/config.php
@@ -14,21 +14,21 @@ $config['pass'] = "";
  * 部屋データを置くディレクトリへのパスです
  * カスタマイズする場合は良しなに...
  */
-$config['roomSavepath'] = __DIR__."/../../room/";
+$config['roomSavepath'] = __DIR__ . "/../../room/";
 
 /*
  * bcdiceへのURL
  * ダイスボットへのパスを書いてください
  * デフォルトではindex.phpと同じ階層にあります
  */
-$config['bcdiceURL'] = "localhost/Onset/bcdice/roll.rb";
+$config['bcdiceURL'] = "trpg.moegi.mydns.jp/TRPG/Onset/public_html/bcdice/roll.rb";
 
 /*
  * SSLを有効にするか
  * URLの先頭についてる、httpsってやつです
  * わからない人はいじらないほうがいいと思います
  */
-$config['enableSSL'] = false;
+$config['enableSSL'] = true;
 
 /*
  * 最大部屋数

--- a/Onset/public_html/src/core.php
+++ b/Onset/public_html/src/core.php
@@ -101,6 +101,8 @@ class Logger
         case self::DANGER:
             file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
             break;
+        default:
+            file_put_contents($file, sprintf($format, self::INFO, $log), FILE_APPEND);
         }
     }
 }

--- a/Onset/public_html/src/core.php
+++ b/Onset/public_html/src/core.php
@@ -1,7 +1,6 @@
 <?php
 require_once(dirname(__FILE__).'/config.php');
 
-
 class Onset
 {
     public static function isValidAccess($randKey)
@@ -12,16 +11,14 @@ class Onset
 
     public static function getRoomlist()
     {
-        global $config;
-        $dir = $config['roomSavepath'];
+        $dir = config::roomSavepath;
         $text = file_get_contents($dir.'roomlist');
         return unserialize(rtrim($text));
     }
 
     public static function setRoomlist($roomlist)
     {
-        global $config;
-        $dir = $config['roomSavepath'];
+        $dir = config::roomSavepath;
         $ret = file_put_contents($dir.'roomlist', serialize($roomlist), LOCK_EX);
         return $ret !== FALSE;
     }
@@ -39,18 +36,71 @@ class Onset
 
     public static function diceRoll($chatContent, $diceSystem)
     {
-        global $config;
-        $url = $config['bcdiceURL'];
+        $url = config::bcdiceURL;
 
         $encordedText = urlencode($chatContent);
         $encordedSys  = urlencode($diceSystem);
 
         $s = "";
-        if($config["enableSSL"]) $s = 's';
+        if(config::enableSSL) $s = 's';
         $ret = file_get_contents("http{$s}://{$url}?text={$encordedText}&sys={$encordedSys}");
         if(trim($ret) == '1' || trim($ret) == 'error'){
             $ret = "";
         }
         return str_replace('onset: ', '', $ret);
+    }
+}
+
+/**
+ * Onset logger
+ */
+class Logger
+{
+    /**
+     * @var DEBUG  デバッグ
+     * @var INFO   情報
+     * @var WARN   警告
+     * @var DANGER 異常
+     */
+    const DEBUG  = 'Debug       ';
+    const INFO   = 'Information ';
+    const WARN   = 'Warning     ';
+    const DANGER = 'Danger      ';
+
+    /**
+     * Logging function
+     * ログを$config['saveLog']のファイルに記録します。
+     *
+     * $level にはself::DEBUG, self::INFO, self::WARN, self::DANGER などが入ります。
+     *
+     * e.g. Logger::log('Super error!', Logger::DANGER);
+     *
+     * @param string $log   text
+     * @param string $level Logging level
+     *
+     * @return void
+     */
+    public static function log($log, $level = self::INFO)
+    {
+        global $config;
+
+        $file = $config['saveLog'];
+
+        $format = date('m/d H:i:s ')."%s: %s\n";
+
+        switch ($level) {
+        case self::DEBUG:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::INFO:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::WARN:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        case self::DANGER:
+            file_put_contents($file, sprintf($format, $level, $log), FILE_APPEND);
+            break;
+        }
     }
 }

--- a/Onset/public_html/src/core.php
+++ b/Onset/public_html/src/core.php
@@ -28,6 +28,7 @@ class Onset
 
     public static function jsonStatus($message, $status = 1)
     {
+        header('content-type: application/json; charset=utf-8');
         $json = [
             "status"  => $status,
             "message" => $message
@@ -36,13 +37,13 @@ class Onset
         return json_encode($json);
     }
 
-    public static function diceroll($text, $sys)
+    public static function diceRoll($chatContent, $diceSystem)
     {
         global $config;
         $url = $config['bcdiceURL'];
 
-        $encordedText = urlencode($text);
-        $encordedSys  = urlencode($sys);
+        $encordedText = urlencode($chatContent);
+        $encordedSys  = urlencode($diceSystem);
 
         $s = "";
         if($config["enableSSL"]) $s = 's';

--- a/Onset/public_html/src/createRoom.php
+++ b/Onset/public_html/src/createRoom.php
@@ -11,18 +11,18 @@ try {
 
     if($roomName === false || $roomPw === false) throw new Exception('部屋名かパスワードが空です。');
 
-    if(mb_strlen($roomName) >= $config['maxRoomName']) throw new Exception('部屋名が長すぎます。');
+    if(mb_strlen($roomName) >= config::maxRoomName) throw new Exception('部屋名が長すぎます。');
 
     $roomName = htmlspecialchars($roomName, ENT_QUOTES);
     $roomList = Onset::getRoomlist();
 
     if(isset($roomList[$roomName])) throw new Exception('同名の部屋がすでに存在しています。');
 
-    if(count($roomList) >= $config['roomLimit']) throw new Exception('部屋数制限いっぱいです。');
+    if(count($roomList) >= config::roomLimit) throw new Exception('部屋数制限いっぱいです。');
 
     $roomId = uniqid('', true);
 
-    $roomDir = $config['roomSavepath'].$roomId;
+    $roomDir = config::roomSavepath.$uuid;
 
     if(!mkdir($roomDir)) throw new Exception('部屋ディレクトリ作成に失敗しました。');
 

--- a/Onset/public_html/src/createRoom.php
+++ b/Onset/public_html/src/createRoom.php
@@ -1,51 +1,49 @@
 <?php
-require_once('config.php');
-require_once('core.php');
+require_once 'core.php';
 
 session_start();
 
-$room = isset($_POST['room']) && $_POST['room'] !== "" ? $_POST['room'] : false;
-$pass = isset($_POST['pass']) && $_POST['pass'] !== "" ? $_POST['pass'] : false;
+$roomName = isset($_POST['roomName']) && $_POST['roomName'] !== "" ? $_POST['roomName']   : false;
+$roomPw   = isset($_POST['roomPw'])   && $_POST['roomPw']   !== "" ? $_POST['roomPw'] : false;
 
 try {
-
     if(!Onset::isValidAccess($_POST['rand'])) throw new Exception('不正なアクセス。');
 
-    if($room === false || $pass === false) throw new Exception('部屋名かパスワードが空です。');
+    if($roomName === false || $roomPw === false) throw new Exception('部屋名かパスワードが空です。');
 
-    if(mb_strlen($room) >= $config['maxRoomName']) throw new Exception('部屋名が長すぎます。');
+    if(mb_strlen($roomName) >= $config['maxRoomName']) throw new Exception('部屋名が長すぎます。');
 
-    $room     = htmlspecialchars($room, ENT_QUOTES);
-    $roomlist = Onset::getRoomlist();
+    $roomName = htmlspecialchars($roomName, ENT_QUOTES);
+    $roomList = Onset::getRoomlist();
 
-    if(isset($roomlist[$room])) throw new Exception('同名の部屋がすでに存在しています。');
+    if(isset($roomList[$roomName])) throw new Exception('同名の部屋がすでに存在しています。');
 
-    if(count($roomlist) >= $config['roomLimit']) throw new Exception('部屋数制限いっぱいです。');
+    if(count($roomList) >= $config['roomLimit']) throw new Exception('部屋数制限いっぱいです。');
 
-    $uuid = uniqid('', true);
+    $roomId = uniqid('', true);
 
-    $_dir = $config['roomSavepath'].$uuid;
+    $roomDir = $config['roomSavepath'].$roomId;
 
-    if(!mkdir($_dir)) throw new Exception('部屋ディレクトリ作成に失敗しました。');
+    if(!mkdir($roomDir)) throw new Exception('部屋ディレクトリ作成に失敗しました。');
 
-    if(!mkdir($_dir.'/connect')) throw new Exception('接続ディレクトリ作成に失敗しました。');
+    if(!mkdir($roomDir.'/connect')) throw new Exception('接続ディレクトリ作成に失敗しました。');
 
-    if(!touch($_dir.'/pass.hash'))   throw new Exception('パスワードハッシュの生成に失敗しました。');
-    if(!touch($_dir.'/xxlogxx.txt')) throw new Exception('ログインハッシュの生成に失敗しました。');
+    if(!touch($roomDir.'/pass.hash'))   throw new Exception('パスワードハッシュの生成に失敗しました。');
+    if(!touch($roomDir.'/xxlogxx.txt')) throw new Exception('ログインハッシュの生成に失敗しました。');
 
-    if(!chmod($_dir,                0777)) throw new Exception('パーミッションの変更に失敗しました。');
-    if(!chmod($_dir.'/connect/',    0777)) throw new Exception('パーミッションの変更に失敗しました。');
-    if(!chmod($_dir.'/pass.hash',   0666)) throw new Exception('パーミッションの変更に失敗しました。');
-    if(!chmod($_dir.'/xxlogxx.txt', 0666)) throw new Exception('パーミッションの変更に失敗しました。');
+    if(!chmod($roomDir,                0777)) throw new Exception('パーミッションの変更に失敗しました。');
+    if(!chmod($roomDir.'/connect/',    0777)) throw new Exception('パーミッションの変更に失敗しました。');
+    if(!chmod($roomDir.'/pass.hash',   0666)) throw new Exception('パーミッションの変更に失敗しました。');
+    if(!chmod($roomDir.'/xxlogxx.txt', 0666)) throw new Exception('パーミッションの変更に失敗しました。');
 
-    $hash = password_hash($pass, PASSWORD_DEFAULT);
-    unset($pass);
+    $hash = password_hash($roomPw, PASSWORD_DEFAULT);
+    unset($roomPw);
 
-    if(!file_put_contents($_dir.'/pass.hash', $hash)) throw new Exception('パスワードハッシュのデータ挿入に失敗しました。');
+    if(!file_put_contents($roomDir.'/pass.hash', $hash)) throw new Exception('パスワードハッシュのデータ挿入に失敗しました。');
 
-    $roomlist[$room]["path"] = $uuid;
+    $roomList[$roomName]["path"] = $roomId;
 
-    if(!Onset::setRoomlist($roomlist)) throw new Exception('部屋一覧の処理に失敗しました。');
+    if(!Onset::setRoomlist($roomList)) throw new Exception('部屋一覧の処理に失敗しました。');
 
 } catch(Exception $e) {
     echo Onset::jsonStatus($e->getMessage(), -1);

--- a/Onset/public_html/src/createRoom.php
+++ b/Onset/public_html/src/createRoom.php
@@ -3,8 +3,8 @@ require_once 'core.php';
 
 session_start();
 
-$roomName = isset($_POST['roomName']) && $_POST['roomName'] !== "" ? $_POST['roomName']   : false;
-$roomPw   = isset($_POST['roomPw'])   && $_POST['roomPw']   !== "" ? $_POST['roomPw'] : false;
+$roomName = isset($_POST['roomName']) && $_POST['roomName'] !== "" ? $_POST['roomName'] : false;
+$roomPw   = isset($_POST['roomPw'])   && $_POST['roomPw']   !== "" ? $_POST['roomPw']   : false;
 
 try {
     if(!Onset::isValidAccess($_POST['rand'])) throw new Exception('不正なアクセス。');
@@ -22,7 +22,7 @@ try {
 
     $roomId = uniqid('', true);
 
-    $roomDir = config::roomSavepath.$uuid;
+    $roomDir = config::roomSavepath.$roomId;
 
     if(!mkdir($roomDir)) throw new Exception('部屋ディレクトリ作成に失敗しました。');
 

--- a/Onset/public_html/src/createRoom.php
+++ b/Onset/public_html/src/createRoom.php
@@ -11,18 +11,18 @@ try {
 
     if($roomName === false || $roomPw === false) throw new Exception('部屋名かパスワードが空です。');
 
-    if(mb_strlen($roomName) >= config::maxRoomName) throw new Exception('部屋名が長すぎます。');
+    if(mb_strlen($roomName) >= Config::maxRoomName) throw new Exception('部屋名が長すぎます。');
 
     $roomName = htmlspecialchars($roomName, ENT_QUOTES);
     $roomList = Onset::getRoomlist();
 
     if(isset($roomList[$roomName])) throw new Exception('同名の部屋がすでに存在しています。');
 
-    if(count($roomList) >= config::roomLimit) throw new Exception('部屋数制限いっぱいです。');
+    if(count($roomList) >= Config::roomLimit) throw new Exception('部屋数制限いっぱいです。');
 
     $roomId = uniqid('', true);
 
-    $roomDir = config::roomSavepath.$roomId;
+    $roomDir = Config::roomSavepath.$roomId;
 
     if(!mkdir($roomDir)) throw new Exception('部屋ディレクトリ作成に失敗しました。');
 

--- a/Onset/public_html/src/delLeftRoom.php
+++ b/Onset/public_html/src/delLeftRoom.php
@@ -2,7 +2,7 @@
 // TODO: 変数の統一
 require_once 'core.php';
 
-$limitLeftTime = config::roomDelTime;
+$limitLeftTime = Config::roomDelTime;
 
 $roomList = Onset::getRoomlist();
 $i = 0;

--- a/Onset/public_html/src/delLeftRoom.php
+++ b/Onset/public_html/src/delLeftRoom.php
@@ -1,13 +1,13 @@
 <?php
+// TODO: 変数の統一
 require_once 'core.php';
 
-// TODO: 変数の統一
-$dir = $config['roomSavepath'];
-$limitLeftTime = $config['roomDelTime'];
-$roomlist = Onset::getRoomlist();
+$limitLeftTime = config::roomDelTime;
+
+$roomList = Onset::getRoomlist();
 $i = 0;
 
-foreach ($roomlist as $room => $data) {
+foreach ($roomList as $room => $data) {
     $roompath = $data['path'];
     $leftTime = filemtime($dir.$roompath);
 

--- a/Onset/public_html/src/delLeftRoom.php
+++ b/Onset/public_html/src/delLeftRoom.php
@@ -1,7 +1,7 @@
 <?php
-require_once('config.php');
-require_once('core.php');
+require_once 'core.php';
 
+// TODO: 変数の統一
 $dir = $config['roomSavepath'];
 $limitLeftTime = $config['roomDelTime'];
 $roomlist = Onset::getRoomlist();

--- a/Onset/public_html/src/login.php
+++ b/Onset/public_html/src/login.php
@@ -7,13 +7,13 @@ $roomPw     = isset($_POST['roomPw'])     || $_POST['roomPw']     !== '' ? $_POS
 
 try {
     if($playerName === false || $roomName === false || $roomPw === false) throw new Exception('空欄があります');
-    if(config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
+    if(Config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
 
     $roomList = Onset::getRoomlist();
 
     if(!isset($roomList[$roomName])) throw new Exception('存在しない部屋です');
 
-    $dir      = config::roomSavepath;
+    $dir      = Config::roomSavepath;
     $roomId   = $roomList[$roomName]['path'];
     $roomDir  = $dir.$roomId;
 

--- a/Onset/public_html/src/login.php
+++ b/Onset/public_html/src/login.php
@@ -7,13 +7,13 @@ $roomPw     = isset($_POST['roomPw'])     || $_POST['roomPw']     !== '' ? $_POS
 
 try {
     if($playerName === false || $roomName === false || $roomPw === false) throw new Exception('空欄があります');
-    if($config['maxNick'] <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
+    if(config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
 
     $roomList = Onset::getRoomlist();
 
     if(!isset($roomList[$roomName])) throw new Exception('存在しない部屋です');
 
-    $dir      = $config['roomSavepath'];
+    $dir      = config::roomSavepath;
     $roomId   = $roomList[$roomName]['path'];
     $roomDir  = $dir.$roomId;
 

--- a/Onset/public_html/src/login.php
+++ b/Onset/public_html/src/login.php
@@ -1,38 +1,35 @@
 <?php
-require_once('config.php');
-require_once('core.php');
+require_once 'core.php';
 
-$nick = isset($_POST['nick']) || $_POST['nick'] !== '' ? htmlspecialchars($_POST['nick'], ENT_QUOTES) : FALSE;
-$pass = isset($_POST['pass']) || $_POST['pass'] !== '' ? $_POST['pass'] : FALSE;
-$room = isset($_POST['room']) || $_POST['room'] !== '' ? htmlspecialchars($_POST['room'], ENT_QUOTES) : FALSE;
+$playerName = isset($_POST['playerName']) || $_POST['playerName'] !== '' ? htmlspecialchars($_POST['playerName'], ENT_QUOTES) : FALSE;
+$roomName   = isset($_POST['roomName'])   || $_POST['roomName']   !== '' ? htmlspecialchars($_POST['roomName'], ENT_QUOTES)   : FALSE;
+$roomPw     = isset($_POST['roomPw'])     || $_POST['roomPw']     !== '' ? $_POST['roomPw']                                   : FALSE;
 
 try {
-    if($nick === false || $pass === false || $room === false) throw new Exception('空欄があります');
-    if($config['maxNick'] <= mb_strlen($nick)) throw new Exception('名前が長すぎます ('. mb_strlen($nick) .')');
+    if($playerName === false || $roomName === false || $roomPw === false) throw new Exception('空欄があります');
+    if($config['maxNick'] <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
 
-    $roomlist = Onset::getRoomlist();
+    $roomList = Onset::getRoomlist();
 
-    if(!isset($roomlist[$room])) throw new Exception('存在しない部屋です');
+    if(!isset($roomList[$roomName])) throw new Exception('存在しない部屋です');
 
-    $roompath = $roomlist[$room]['path'];
     $dir      = $config['roomSavepath'];
-    $_dir     = $dir.$roompath;
-    $hash     = file_get_contents($_dir.'/pass.hash');
+    $roomId   = $roomList[$roomName]['path'];
+    $roomDir  = $dir.$roomId;
 
-    if(!password_verify($pass, $hash) && $config['pass'] != $pass) throw new Exception('パスワードが間違っています');
+    $passHash = file_get_contents($roomDir.'/pass.hash');
 
+    if(!password_verify($roomPw, $passHash) && $config['pass'] != $roomPw) throw new Exception('パスワードが間違っています');
 
 } catch (Exception $e) {
     echo Onset::jsonStatus($e->getMessage(), -1);
     die();
 }
 
-$id = ip2long($_SERVER['REMOTE_ADDR']) + mt_rand();
-
 session_start();
 
-$_SESSION['onset_nick'] = $nick;
-$_SESSION['onset_room'] = $roompath;
-$_SESSION['onset_id']   = dechex($id);
+$_SESSION['onset_playerid']   = dechex(ip2long($_SERVER['REMOTE_ADDR']) + mt_rand());
+$_SESSION['onset_playername'] = $playerName;
+$_SESSION['onset_roomid']     = $roomId;
 
 echo Onset::jsonStatus('認証OK');

--- a/Onset/public_html/src/logput.php
+++ b/Onset/public_html/src/logput.php
@@ -7,9 +7,10 @@ if(!isset($_SESSION['onset_roomid'])){
     echo "不正なアクセスです";
     die();
 }
-$dir     = $config['roomSavepath'];
-$roomDir = $dir.$_SESSION['onset_roomid']."/xxlogxx.txt";
-$text    = htmlspecialchars_decode(strip_tags(file_get_contents($roomDir)));
+
+$dir = config::roomSavepath;
+$chatLog = $dir.$_SESSION['onset_roomid']."/xxlogxx.txt";
+$text    = htmlspecialchars_decode(strip_tags(file_get_contents($chatLog)));
 
 header("Content-type: text/plain");
 echo $text;

--- a/Onset/public_html/src/logput.php
+++ b/Onset/public_html/src/logput.php
@@ -1,16 +1,15 @@
 <?php
-require_once('config.php');
-require_once('core.php');
+require_once 'core.php';
 
 session_start();
 
-if(!isset($_SESSION['onset_room'])){
+if(!isset($_SESSION['onset_roomid'])){
     echo "不正なアクセスです";
     die();
 }
-$dir = $config['roomSavepath'];
-$logdir = $dir.$_SESSION['onset_room']."/xxlogxx.txt";
-$text = htmlspecialchars_decode(strip_tags(file_get_contents($logdir)));
+$dir     = $config['roomSavepath'];
+$roomDir = $dir.$_SESSION['onset_roomid']."/xxlogxx.txt";
+$text    = htmlspecialchars_decode(strip_tags(file_get_contents($roomDir)));
 
 header("Content-type: text/plain");
 echo $text;

--- a/Onset/public_html/src/logput.php
+++ b/Onset/public_html/src/logput.php
@@ -8,7 +8,7 @@ if(!isset($_SESSION['onset_roomid'])){
     die();
 }
 
-$dir = config::roomSavepath;
+$dir = Config::roomSavepath;
 $chatLog = $dir.$_SESSION['onset_roomid']."/xxlogxx.txt";
 $text    = htmlspecialchars_decode(strip_tags(file_get_contents($chatLog)));
 

--- a/Onset/public_html/src/read.php
+++ b/Onset/public_html/src/read.php
@@ -11,7 +11,7 @@ if ($time === false || $roomId === false) {
     die();
 }
 
-$roomDir = config::roomSavepath.$roomId;
+$roomDir = Config::roomSavepath.$roomId;
 
 if ($time < filemtime($roomDir."/xxlogxx.txt") * 1000) {
     $fp = fopen($roomDir."/xxlogxx.txt", 'r');

--- a/Onset/public_html/src/read.php
+++ b/Onset/public_html/src/read.php
@@ -11,7 +11,7 @@ if ($time === false || $roomId === false) {
     die();
 }
 
-$roomDir = $config['roomSavepath'].$roomId;
+$roomDir = config::roomSavepath.$roomId;
 
 if ($time < filemtime($roomDir."/xxlogxx.txt") * 1000) {
     $fp = fopen($roomDir."/xxlogxx.txt", 'r');

--- a/Onset/public_html/src/read.php
+++ b/Onset/public_html/src/read.php
@@ -1,21 +1,20 @@
 <?php
-require_once('core.php');
-require_once('config.php');
+require_once 'core.php';
 
 session_start();
 
-$time = isset($_POST['time'])          && $_POST['time']          !== '' ? $_POST['time']          : false;
-$room = isset($_SESSION['onset_room']) && $_SESSION['onset_room'] !== '' ? $_SESSION['onset_room'] : false;
+$time   = isset($_POST['time'])            && $_POST['time']            !== '' ? $_POST['time']          : false;
+$roomId = isset($_SESSION['onset_roomid']) && $_SESSION['onset_roomid'] !== '' ? $_SESSION['onset_roomid'] : false;
 
-if ($time === false || $room === false) {
+if ($time === false || $roomId === false) {
     echo Onset::jsonStatus("不正なアクセス", -1);
     die();
 }
 
-$_dir = $config['roomSavepath'].$room;
+$roomDir = $config['roomSavepath'].$roomId;
 
-if ($time < filemtime($_dir."/xxlogxx.txt") * 1000) {
-    $fp = fopen($_dir."/xxlogxx.txt", 'r');
+if ($time < filemtime($roomDir."/xxlogxx.txt") * 1000) {
+    $fp = fopen($roomDir."/xxlogxx.txt", 'r');
 
     do {
         $line = fgets($fp);
@@ -27,7 +26,7 @@ if ($time < filemtime($_dir."/xxlogxx.txt") * 1000) {
     echo "none";
 }
 
-$tmp = $_dir."/connect/".$_SESSION['onset_id'];
-file_put_contents($tmp, time()."\n".$_SESSION['onset_nick'], LOCK_EX);
+$tmp = $roomDir."/connect/".$_SESSION['onset_playerid'];
+file_put_contents($tmp, time()."\n".$_SESSION['onset_playername'], LOCK_EX);
 
 clearstatcache();

--- a/Onset/public_html/src/removeRoom.php
+++ b/Onset/public_html/src/removeRoom.php
@@ -15,12 +15,12 @@ try {
 
     if (!isset($roomList[$roomName])) throw new Exception('部屋が存在しません');
 
-    $dir      = config::roomSavepath;
+    $dir      = Config::roomSavepath;
     $roomId   = $roomList[$roomName]['path'];
     $roomDir  = $dir.$roomId;
     $passHash = file_get_contents($roomDir.'/pass.hash');
 
-    if (!password_verify($roomPw, $passHash) && $roomPw != config::pass) throw new Exception('パスワードを間違えています');
+    if (!password_verify($roomPw, $passHash) && $roomPw != Config::pass) throw new Exception('パスワードを間違えています');
 
     foreach (scandir($roomDir.'/connect/') as $k) {
         if ($k == '.' || $k == '..') continue;

--- a/Onset/public_html/src/removeRoom.php
+++ b/Onset/public_html/src/removeRoom.php
@@ -1,46 +1,44 @@
 <?php
-require_once('config.php');
-require_once('core.php');
+require_once 'core.php';
 
 session_start();
 
 try {
-
     if (!Onset::isValidAccess($_POST['rand'])) throw new Exception('不正なアクセス。');
 
-    $room = isset($_POST['room']) && $_POST['room'] !== "" ? htmlspecialchars($_POST['room'], ENT_QUOTES) : false;
-    $pass = isset($_POST['pass']) && $_POST['pass'] !== "" ? $_POST['pass'] : false;
+    $roomName = isset($_POST['roomName']) && $_POST['roomName'] !== "" ? htmlspecialchars($_POST['roomName'], ENT_QUOTES) : false;
+    $roomPw   = isset($_POST['roomPw'])   && $_POST['roomPw']   !== "" ? $_POST['roomPw']                                 : false;
 
-    if ($room === false || $pass === false) throw new Exception('ルーム名かパスワードがセットされていません');
+    if ($roomName === false || $roomPw === false) throw new Exception('ルーム名かパスワードがセットされていません');
 
-    $roomlist = Onset::getRoomlist();
+    $roomList = Onset::getroomList();
 
-    if (!isset($roomlist[$room])) throw new Exception('部屋が存在しません');
+    if (!isset($roomList[$roomName])) throw new Exception('部屋が存在しません');
 
-    $roompath = $roomlist[$room]['path'];
     $dir      = $config['roomSavepath'];
-    $_dir     = $dir.$roompath;
-    $hash     = file_get_contents($_dir.'/pass.hash');
+    $roomId   = $roomList[$roomName]['path'];
+    $roomDir  = $dir.$roomId;
+    $passHash = file_get_contents($roomDir.'/pass.hash');
 
-    if (!password_verify($pass, $hash) && $pass != $config['pass']) throw new Exception('パスワードを間違えています');
+    if (!password_verify($roomPw, $passHash) && $roomPw != $config['pass']) throw new Exception('パスワードを間違えています');
 
-    foreach (scandir($_dir.'/connect/') as $k) {
+    foreach (scandir($roomDir.'/connect/') as $k) {
         if ($k == '.' || $k == '..') continue;
-        if (!unlink($_dir.'/connect/'.$k)) throw new Exception('接続ディレクトリの削除に失敗。');
+        if (!unlink($roomDir.'/connect/'.$k)) throw new Exception('接続ディレクトリの削除に失敗。');
     }
 
-    if (!rmdir($_dir.'/connect/')) throw new Exception('接続ディレクトリの削除に失敗。');
+    if (!rmdir($roomDir.'/connect/')) throw new Exception('接続ディレクトリの削除に失敗。');
 
-    foreach (scandir($_dir) as $k) {
+    foreach (scandir($roomDir) as $k) {
         if ($k == '.' || $k == '..') continue;
-        if (!unlink($_dir.'/'.$k)) throw new Exception('部屋ディレクトリの削除に失敗。');
+        if (!unlink($roomDir.'/'.$k)) throw new Exception('部屋ディレクトリの削除に失敗。');
     }
 
-    if (!rmdir($_dir)) throw new Exception('部屋ディレクトリの削除に失敗。');
+    if (!rmdir($roomDir)) throw new Exception('部屋ディレクトリの削除に失敗。');
 
-    unset($roomlist[$room]);
+    unset($roomList[$roomName]);
 
-    if (!Onset::setRoomlist($roomlist)) throw new Exception('部屋リストからの削除に失敗');
+    if (!Onset::setRoomList($roomList)) throw new Exception('部屋リストからの削除に失敗');
 } catch (Exception $e) {
     echo Onset::jsonStatus($e->getMessage(), -1);
     die();

--- a/Onset/public_html/src/removeRoom.php
+++ b/Onset/public_html/src/removeRoom.php
@@ -15,12 +15,12 @@ try {
 
     if (!isset($roomList[$roomName])) throw new Exception('部屋が存在しません');
 
-    $dir      = $config['roomSavepath'];
+    $dir      = config::roomSavepath;
     $roomId   = $roomList[$roomName]['path'];
     $roomDir  = $dir.$roomId;
     $passHash = file_get_contents($roomDir.'/pass.hash');
 
-    if (!password_verify($roomPw, $passHash) && $roomPw != $config['pass']) throw new Exception('パスワードを間違えています');
+    if (!password_verify($roomPw, $passHash) && $roomPw != config::pass) throw new Exception('パスワードを間違えています');
 
     foreach (scandir($roomDir.'/connect/') as $k) {
         if ($k == '.' || $k == '..') continue;

--- a/Onset/public_html/src/write.php
+++ b/Onset/public_html/src/write.php
@@ -17,10 +17,10 @@ try {
 
     require_once('config.php');
 
-    if (config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
-    if (config::maxText <= mb_strlen($chatContent)) throw new Exception('テキストが長すぎます ('. mb_strlen($chatContent) .')');
+    if (Config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
+    if (Config::maxText <= mb_strlen($chatContent)) throw new Exception('テキストが長すぎます ('. mb_strlen($chatContent) .')');
 
-    $roomDir = config::roomSavepath.$roomId;
+    $roomDir = Config::roomSavepath.$roomId;
 
     $diceRes = Onset::diceRoll($chatContent, $diceSystem);
 

--- a/Onset/public_html/src/write.php
+++ b/Onset/public_html/src/write.php
@@ -3,7 +3,7 @@ require_once 'core.php';
 
 session_start();
 
-$playerName  = isset($_POST['playerName'])      && $_POST['nick']            !== '' ? trim($_POST['playerName'])  : FALSE;
+$playerName  = isset($_POST['playerName'])      && $_POST['playerName']            !== '' ? trim($_POST['playerName'])  : FALSE;
 $chatContent = isset($_POST['chatContent'])     && $_POST['chatContent']     !== '' ? trim($_POST['chatContent']) : FALSE;
 $diceSystem  = isset($_POST['diceSystem'])      && $_POST['diceSystem']      !== '' ? trim($_POST['diceSystem'])  : FALSE;
 $roomId      = isset($_SESSION['onset_roomid']) && $_SESSION['onset_roomid'] !== '' ? $_SESSION['onset_roomid']   : FALSE;

--- a/Onset/public_html/src/write.php
+++ b/Onset/public_html/src/write.php
@@ -1,5 +1,5 @@
 <?php
-require_once('core.php');
+require_once 'core.php';
 
 session_start();
 
@@ -17,10 +17,10 @@ try {
 
     require_once('config.php');
 
-    $roomDir = $config['roomSavepath'].$roomId;
+    if (config::maxNick <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
+    if (config::maxText <= mb_strlen($chatContent)) throw new Exception('テキストが長すぎます ('. mb_strlen($chatContent) .')');
 
-    if ($config['maxNick'] <= mb_strlen($playerName)) throw new Exception('名前が長すぎます ('. mb_strlen($playerName) .')');
-    if ($config['maxText'] <= mb_strlen($chatContent)) throw new Exception('テキストが長すぎます ('. mb_strlen($chatContent) .')');
+    $roomDir = config::roomSavepath.$roomId;
 
     $diceRes = Onset::diceRoll($chatContent, $diceSystem);
 


### PR DESCRIPTION
変更内容は以下のとおり:
## 変数

| 変更前 | 変更先 | 説明 |
| :-- | :-- | :-- |
| `$_SESSION['onset_room']` | `$_SESSION['onset_roomid]` | 部屋のID(セッション) |
| `$_SESSION['onset_id']` | `$_SESSION['onset_playerid']` | ユーザID(セッション) |
| `$_SESSION['onset_nick']` | `$_SESSION['onset_playername']` | ユーザ名(セッション) |
| `$nick` | `$playerName` | プレイヤー名 |
| `$text` | `$chatContent` | チャット内容 |
| `$sys` | `$diceSystem` | BCDiceのシステム |
| `$room` | `$roomId` / `$roomName` | 部屋ID / 部屋名 (コードによる) |
| `$_dir` | `$roomDir` | 部屋ディレクトリ |
| `$roompath` | `$roomId` | 部屋のID |
| `$roomlist` | `$roomList`(キャメルケース化) | →`room/roomlist` |

その他大勢。一時的な変数は省略。
## クラス

`class config`が`class Config`と大文字綴りになりました。
## ロガー

`$level`に異常な値が入った時の挙動改善
